### PR TITLE
Specify an install target for the cvmfs-snapshot service.

### DIFF
--- a/cvmfs-snapshot.service
+++ b/cvmfs-snapshot.service
@@ -15,3 +15,7 @@ StandardOutput=journal
 
 ExecStart=/usr/bin/echo "Starting CVMFS Stratum-1 Snapshot service."
 
+# If the server is enabled, then have it startup with the multi-user
+# target.
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
With this, `systemctl enable` should "do the right thing" and start this service at boot.

Fix #5